### PR TITLE
Fix GetDataFilePath and GetModFileList

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,19 @@
 
 This is simple installer plugin for Mod Organizer 2 to handle FOMOD installers containing C# script.
 
-Without this plugin, Mod Organizer 2 will use NCC to install such plugins, but NCC as a few limitations when used with MO2 :
+Without this plugin, Mod Organizer 2 will use NCC to install such plugins, but NCC has a few limitations when
+used within MO2:
 
 - Mod detection will not work, so the installer will not be able to check for active mods or even existing files.
-- Modifying settings file (FalloutNV.ini, etc.) does not work properly with the NCC installer.
+- Modifying settings (`FalloutNV.ini`, etc.) does not work properly with the NCC installer (it may work if you
+    do not use per-profile settings, but that is not recommended).
 
-This installer is better integrated with Mod Organizer 2, but still has some limitations:
+This installer is better integrated with Mod Organizer 2 and should handle any kind of FOMOD installer containing
+a C# script. Feel free to [open an issue](https://github.com/ModOrganizer2/modorganizer/issues/new?assignees=&labels=issue+report&template=issue-report.md)
+if you find a bug.
 
-- Files created by the installer (not files extracted) cannot be handled by the installer, thus those will be put in your Overwrites directory and you will be notified of their creation. You will then need to move these files to the installed mods manually.
-- Settings files are not updated automatically to avoid overriding settings you do not want. Instead, a dialog will tell you which settings the mods want you to modify at the end of the installation.
+The installer will never modify settings silently. If during installation, the script tries to modify settings,
+they will be stored in memory and presented to you at the end of the installation. You will then be able to either
+apply the settings, save them inside the mod folder or discard them.
 
-If a mod does not create new files or does not modify settings file, you will not see any dialog at the end of the installation.
-
-**Warning:** This plugin currently only works with Mod Organizer 2 development build 2.3.0 alpha 8!
+**Warning:** This plugin currently only works with Mod Organizer 2 development build 2.3.0 alpha 10!

--- a/src/base_script.cpp
+++ b/src/base_script.cpp
@@ -212,7 +212,9 @@ namespace CSharp {
       if (isFomodEntry(entry)) {
         return IFileTree::WalkReturn::SKIP;
       }
-      paths.push_back(path + entry->name());
+      if (entry->isFile()) {
+        paths.push_back(path + entry->name());
+      }
       return IFileTree::WalkReturn::CONTINUE;
     }, "/");
 

--- a/src/installer_fomod_csharp.cpp
+++ b/src/installer_fomod_csharp.cpp
@@ -177,8 +177,6 @@ InstallerFomodCSharp::EInstallResult InstallerFomodCSharp::install(MOBase::Guess
   }
   modName.update(dialog.getName(), GUESS_USER);
 
-  // entryToPath[scriptFile] = "I:\\Projects\\ModOrganizer2\\script2.cs";
-
   // Run the C# script:
   const QString scriptPath = entryToPath[scriptFile];
   CSharp::beforeInstall(this, manager(), parentWidget(), std::const_pointer_cast<IFileTree>(scriptFile->parent()->parent()), std::move(entryToPath));

--- a/src/installer_fomod_csharp_en.ts
+++ b/src/installer_fomod_csharp_en.ts
@@ -6,7 +6,6 @@
     <message>
         <location filename="installer_fomod_csharp_postdialog.ui" line="14"/>
         <source>Settings modification required</source>
-        <oldsource>Manual steps required</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -89,13 +88,13 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installer_fomod_csharp_predialog.ui" line="92"/>
-        <source>Cancel</source>
+        <location filename="installer_fomod_csharp_predialog.ui" line="82"/>
+        <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installer_fomod_csharp_predialog.ui" line="82"/>
-        <source>Start</source>
+        <location filename="installer_fomod_csharp_predialog.ui" line="92"/>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -118,12 +117,12 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="base_script.cpp" line="483"/>
+        <location filename="base_script.cpp" line="504"/>
         <source>Choose any:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="base_script.cpp" line="486"/>
+        <location filename="base_script.cpp" line="507"/>
         <source>Choose one:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/installer_fomod_csharp_en.ts
+++ b/src/installer_fomod_csharp_en.ts
@@ -117,12 +117,12 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="base_script.cpp" line="504"/>
+        <location filename="base_script.cpp" line="506"/>
         <source>Choose any:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="base_script.cpp" line="507"/>
+        <location filename="base_script.cpp" line="509"/>
         <source>Choose one:</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/installer_fomod_csharp_en.ts
+++ b/src/installer_fomod_csharp_en.ts
@@ -118,12 +118,12 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="base_script.cpp" line="395"/>
+        <location filename="base_script.cpp" line="483"/>
         <source>Choose any:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="base_script.cpp" line="398"/>
+        <location filename="base_script.cpp" line="486"/>
         <source>Choose one:</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
`GetModFileList` previously returned files and folders. This was not NCC behavior and makes some mods crash, so now returning only files.

`GetExistingDataFile` can be called for a file that has been extracted by the installer itself (e.g., the MCM installer for FNV). This fix cases where the file queried was installed (extracted) by the installer itself, but from a subfolder (e.g., the `menus` folder was installed and the `menus/info.xml` file is queried).